### PR TITLE
Only update changelog when response has it

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -274,7 +274,9 @@ jQuery( document ).ready( function ( $ ) {
 						that.setUpgradeFile();
 						if ( 'checked' == $( '#edd_license_enabled' ).attr( 'checked' ) ) {
 							$( '#edd_sl_version' ).val( response.sl_version );
-							tinyMCE.get( 'edd_sl_changelog' ).setContent( response.changelog );						
+							if ( response.changelog ) {	
+								tinyMCE.get( 'edd_sl_changelog' ).setContent( response.changelog );
+							}
 						}
 						$( '#edd_git_file' ).val( response.file );	
 						$( document ).trigger( 'eddGitFileFetched' );


### PR DESCRIPTION
Not sure exactly why, but I kept getting a JS error when trying to Fetch stating that couldn't 'setContent' with an item that didn't exist. Just wrapping the setContent with a check to see if the response contains the `changelog` item first.